### PR TITLE
Use items instead of viewitems

### DIFF
--- a/parse/parser.py
+++ b/parse/parser.py
@@ -221,7 +221,7 @@ def MergeSignatures(signatures):
 
   # TODO: Return this as a dictionary.
   return [pytd.Function(name, tuple(signatures))
-          for name, signatures in name_to_signatures.viewitems()]
+          for name, signatures in name_to_signatures.items()]
 
 
 class Mutator(object):


### PR DESCRIPTION
While `OrderedDict.items` != `OrderedDict.viewitems` in py2 (`viewitems` being py3 version), I believe for this particular case it doesn't matter (and items works on both versions).

Changing this line allowed me to use the parser in python3
